### PR TITLE
"Singular they" fixup

### DIFF
--- a/Section_I/fourth_official.tex
+++ b/Section_I/fourth_official.tex
@@ -7,15 +7,15 @@
 \bigskip
 
 \begin{itemize}
-\item A fourth official may be appointed under the competition rules and officiates if any of the three match officials is unable to continue, unless a reserve assistant referee is appointed. They assists the referee at all times
+\item A fourth official may be appointed under the competition rules and officiates if any of the three match officials is unable to continue, unless a reserve assistant referee is appointed. They assist the referee at all times
 \item Prior to the start of the competition, the organiser states clearly whether, if the referee is unable to continue, the fourth official takes over as the referee or whether the senior assistant referee takes over as referee with the fourth official becoming an assistant referee
 \item The fourth official assists with any administrative duties before, during and after the match, as required by the referee
-\item They is responsible for assisting with substitution procedures during the match
-\item They has the authority to check the equipment of substitutes before they enter the field of play. If their equipment does not comply with the Laws of the Game, they informs the referee
-\item They supervises the replacement balls, where required. If the match ball has to be replaced during a match, they provides another ball, on the instruction of the referee, thus keeping the delay to a minimum
-\item They assists the referee to control the match in accordance with the Laws of the Game. The referee, however, retains the authority to decide on
+\item They are responsible for assisting with substitution procedures during the match
+\item They have the authority to check the equipment of substitutes before they enter the field of play. If their equipment does not comply with the Laws of the Game, they inform the referee
+\item They supervise the replacement balls, where required. If the match ball has to be replaced during a match, they provide another ball, on the instruction of the referee, thus keeping the delay to a minimum
+\item They assist the referee to control the match in accordance with the Laws of the Game. The referee, however, retains the authority to decide on
 all points connected with play.
 \item After the match, the fourth official must submit a report to the appropriate authorities on any misconduct or other incident that occurred out of the view of the referee and the assistant referees. The fourth official must advise the referee and their assistants of any report being made
-\item They has the authority to inform the referee of irresponsible behaviour by any occupant of the technical area
-\item A reserve assistant referee may also be appointed under competition rules. Their  only duty shall be to replace an assistant referee who is unable to continue or to replace the fourth official, as required
+\item They have the authority to inform the referee of irresponsible behaviour by any occupant of the technical area
+\item A reserve assistant referee may also be appointed under competition rules. Their only duty shall be to replace an assistant referee who is unable to continue or to replace the fourth official, as required
 \end{itemize}

--- a/Section_I/law5.tex
+++ b/Section_I/law5.tex
@@ -63,7 +63,13 @@ The referee may only change a decision on realising that it is incorrect or, at 
 
 Decision 1
 
-A referee (or where applicable, an assistant referee or fourth official) is not held liable for: any kind of injury suffered by a player, official or spectator any damage to property of any kind any other loss suffered by any individual, club, company, association or other body, which is due or which may be due to any decision that they may take under the terms of the Laws of the Game or in respect of the normal procedures required to hold, play and control a match.
+A referee (or where applicable, an assistant referee or fourth official) is not held liable for:
+
+any kind of injury suffered by a player, official or spectator
+
+any damage to property of any kind
+
+any other loss suffered by any individual, club, company, association or other body, which is due or which may be due to any decision that they may take under the terms of the Laws of the Game or in respect of the normal procedures required to hold, play and control a match.
 
 \bigskip
 

--- a/Section_I/law5.tex
+++ b/Section_I/law5.tex
@@ -11,7 +11,7 @@ Law 5 -- The Referee}
 
 \headlinebox
 
-Each match is controlled by a referee who has full authority to enforce the Laws of the Game in connection with the match to which they has been appointed.
+Each match is controlled by a referee who has full authority to enforce the Laws of the Game in connection with the match to which they have been appointed.
 
 \bigskip
 
@@ -34,7 +34,7 @@ The Referee:
 \item ensures that any player bleeding from a wound leaves the field of play. The player may only return on receiving a signal from the referee, who must be satisfied that the bleeding has stopped
 \item allows play to continue when the team against which an offence has been committed will benefit from such an advantage and penalises the original offence if the anticipated advantage does not ensue at that time
 \item punishes the more serious offence when a player commits more than one offence at the same time
-\item takes disciplinary action against players guilty of cautionable and sending-off offences. They is not obliged to take this action immediately but must do so when the ball next goes out of play 
+\item takes disciplinary action against players guilty of cautionable and sending-off offences. They are not obliged to take this action immediately but must do so when the ball next goes out of play 
 \item takes action against team officials who fail to conduct themselves in a responsible manner and may, at their discretion, expel them from the field of play and its immediate surrounds 
 \item acts on the advice of the assistant referees regarding incidents that they has not seen 
 \item ensures that no unauthorised persons enter the field of play 
@@ -53,7 +53,7 @@ The decisions of the referee regarding facts connected with play, including whet
 
 \bigskip
 
-The referee may only change a decision on realising that it is incorrect or, at their discretion, on the advice of an assistant referee or the fourth official, provided that they has not restarted play or terminated the match.
+The referee may only change a decision on realising that it is incorrect or, at their discretion, on the advice of an assistant referee or the fourth official, provided that they have not restarted play or terminated the match.
 
 
 \clearpage
@@ -83,7 +83,7 @@ Such decisions may include:
 \item a decision to stop or not to stop play to allow an injured player to be removed from the field of play for treatment 
 \item a decision to require an injured player to be removed from the field of play for treatment 
 \item a decision to allow or not to allow a player to wear certain apparel or equipment 
-\item a decision (where they has the authority) to allow or not to allow any persons (including team or stadium officials, security officers, photographers or other media representatives) to be present in the vicinity of the field of play 
+\item a decision (where they have the authority) to allow or not to allow any persons (including team or stadium officials, security officers, photographers or other media representatives) to be present in the vicinity of the field of play 
 \item any other decision that they may take in accordance with the Laws of the Game or in conformity with their duties under the terms of FIFA, confederation, member association or league rules or regulations under which the match is played 
 \end{itemize}
 

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -227,9 +227,9 @@ the game anyway. A timeout ends automatically after 120 s. A timeout also ends w
 
 \color{magenta}{
 {\bfseries Referee Timeouts}
-The head referee may call a timeout at any stoppage of play if they deems it necessary. A referee timeout should only be called in dire circumstances - one example might be when the power to the wireless router is down. However, when and whether to call a referee timeout is left up to the head referee.
+The head referee may call a timeout at any stoppage of play if they deem it necessary. A referee timeout should only be called in dire circumstances - one example might be when the power to the wireless router is down. However, when and whether to call a referee timeout is left up to the head referee.
 
-Referees may call multiple timeouts during a game if needed. Teams may do anything during these timeouts, but they must be ready to play 2 minutes after the referee begins a timeout. The referee should end the timeout once they believes the circumstance for which the timeout was called has been resolved. In cases where the circumstance for which the timeout was called is not resolved within 10 minutes, the Technical Committee should be consulted regarding when/if play should continue.
+Referees may call multiple timeouts during a game if needed. Teams may do anything during these timeouts, but they must be ready to play 2 minutes after the referee begins a timeout. The referee should end the timeout once they believe the circumstance for which the timeout was called has been resolved. In cases where the circumstance for which the timeout was called is not resolved within 10 minutes, the Technical Committee should be consulted regarding when/if play should continue.
 
 The team who would have kicked off if the timeout had not been called shall kickoff when the game resumes.
 


### PR DESCRIPTION
When the rules were made gender neutral wrt references to persons, the verbs were not changed to conjugate accordingly. For instance, 'he has' became 'they has' instead of 'they have'. This PR fixes those, plus a small formatting fix in Law 5