### PR TITLE
Vote4 Variant1 Reducing handler interventions for Adult Size

### DIFF
--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -139,7 +139,7 @@ receives zero points.
 
 For the AdultSize soccer games, a specific rule for robot handlers applies. For every robot, one robot handler is allowed to stay near the robot such that the robot handler does not interfere with the game. Specifically, the robot handler:
 \begin{itemize}
-\item should position himself behind the robot at a distance of at least an arm length away from the robot's convex hull.
+\item should position himself behind the robot at a distance of at least \removed{an arm length} \added{two arm lengths} away from the robot's convex hull.
 \item must not block the vision of any of the robots on the ball or goals.
 \item must not block the path of any robot.
 \item must not touch any robot. Touching a robot is considered an offence that is penalised by a removal penalty of the robot handler's own robot according to the laws of the game.


### PR DESCRIPTION
robot handler:  should position himself behind the robot at a distance of at least TWO arm lengths away from the robot's convex hull.