### PR TITLE
vote7 Team colors assignment

### DIFF
--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -271,8 +271,9 @@ The basic compulsory equipment of a player comprises the following separate item
       legs and chest combined must be at least $0.06\cdot {H_{top}}^2$.
       The visible area of the one to five largest team markers on each side
       (left, right, front and back) must be at least $0.015\cdot {H_{top}}^2$.
-      If both teams cannot agree, which team colour to use, a coin will be
-      flipped an hour prior to the game to assign the team colours.
+      \removed{If both teams cannot agree, which team colour to use, a coin will be
+      flipped an hour prior to the game to assign the team colours.}
+      \added{Team colors are assigned randomly before the competition and are announced in the game schedule.}
 \item (new) The robots of each team must be uniquely identifiable. They must be marked with numbers or names. The goal keeper robot must be marked uniquely that it can be easily distinguished from the other robots of a team by the referees. 
 \item The two teams must wear colours that distinguish them from each other and also the referee and the assistant referees.
 \greyed{\item 


### PR DESCRIPTION
In the virtual competition, the team colors are assigned randomly before the competition and are announced in the game schedule. We could apply the same rule for the physical competition instead of allowing teams to agree on a team color.