### PR TITLE
vote8: Game time extended for penalty kicks 

### DIFF
--- a/Section_I/law7.tex
+++ b/Section_I/law7.tex
@@ -53,12 +53,12 @@ The allowance for time lost is at the discretion of the referee.
 
 \bigskip
 
-{\bfseries Penalty kick}
+{\bfseries \removed{Penalty kick}}
 
 \headlinebox
 
-If a penalty kick has to be taken or retaken, the duration of either half is extended until the penalty kick is completed.
-
+\removed{If a penalty kick has to be taken or retaken, the duration of either half is extended until the penalty kick is completed.
+}
 \bigskip
 
 {\sffamily


### PR DESCRIPTION
In the regular tournament, the game time was extended if penalty kicks occurred during the regular or extended game time. In the virtual rule book, this rule was removed.