### PR TITLE
vote9: Replacing the coin toss by a random decision of the referee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.pdf
 *.out
 *.toc
+RCHL-2020-Rules.fdb_latexmk
+RCHL-2020-Rules.fls
+RCHL-2020-Rules.synctex.gz

--- a/Section_I/law8.tex
+++ b/Section_I/law8.tex
@@ -47,7 +47,7 @@ is awarded to the opposing team.
 Before a kick-off at the start of the match or extra time 
 
 \begin{itemize}
-      \item \removed{a coin is tossed and the team that wins the toss decides which goal it will attack} \added{referee randomly decides which team will attack which goal} in the first half of the match.
+      \item \removed{a coin is tossed and the team that wins the toss decides which goal it will attack} \added{the referee randomly decides which team will attack which goal} in the first half of the match.
       \item \removed{the other} \added{referee randomly decides which} team takes the kick-off to start the match. 
       \item the team that \removed{wins the toss} \added{is other from team taking kick-off at first half} takes the kick-off to start the second half of the match.
 \item in the second half of the match, the teams change ends and attack the opposite goals. 

--- a/Section_I/law8.tex
+++ b/Section_I/law8.tex
@@ -48,7 +48,7 @@ Before a kick-off at the start of the match or extra time
 
 \begin{itemize}
       \item \removed{a coin is tossed and the team that wins the toss decides which goal it will attack} \added{the referee randomly decides which team will attack which goal} in the first half of the match.
-      \item \removed{the other} \added{referee randomly decides which} team takes the kick-off to start the match. 
+      \item \removed{the other} \added{the referee randomly decides which} team takes the kick-off to start the match. 
       \item the team that \removed{wins the toss} \added{is other from team taking kick-off at first half} takes the kick-off to start the second half of the match.
 \item in the second half of the match, the teams change ends and attack the opposite goals. 
 \end{itemize}

--- a/Section_I/law8.tex
+++ b/Section_I/law8.tex
@@ -49,7 +49,7 @@ Before a kick-off at the start of the match or extra time
 \begin{itemize}
       \item \removed{a coin is tossed and the team that wins the toss decides which goal it will attack} \added{the referee randomly decides which team will attack which goal} in the first half of the match.
       \item \removed{the other} \added{the referee randomly decides which} team takes the kick-off to start the match. 
-      \item the team that \removed{wins the toss} \added{is other from team taking kick-off at first half} takes the kick-off to start the second half of the match.
+      \item the team that \removed{wins the toss} \added{was not given kick-off in the first half of the match} takes the kick-off to start the second half of the match.
 \item in the second half of the match, the teams change ends and attack the opposite goals. 
 \end{itemize}
 

--- a/Section_I/law8.tex
+++ b/Section_I/law8.tex
@@ -47,9 +47,9 @@ is awarded to the opposing team.
 Before a kick-off at the start of the match or extra time 
 
 \begin{itemize}
-\item a coin is tossed and the team that wins the toss decides which goal it will attack in the first half of the match.
-\item the other team takes the kick-off to start the match. 
-\item the team that wins the toss takes the kick-off to start the second half of the match.
+      \item \removed{a coin is tossed and the team that wins the toss decides which goal it will attack} \added{referee randomly decides which team will attack which goal} in the first half of the match.
+      \item \removed{the other} \added{referee randomly decides which} team takes the kick-off to start the match. 
+      \item the team that \removed{wins the toss} \added{is other from team taking kick-off at first half} takes the kick-off to start the second half of the match.
 \item in the second half of the match, the teams change ends and attack the opposite goals. 
 \end{itemize}
 


### PR DESCRIPTION
In the physical competition, a coin is tossed and the winner gets to decide whether they want to pick a side to play at for the first half time, or whether they want to have the first kick-off. In the virtual competition, both decisions are taken randomly by the referee. The proposal would be to replace the coin toss with the random decision of the referee for the physical competition as well (both for the regular tournament and penalty shoot-outs).