### PR TITLE
vote11: Yellow cards for team

### DIFF
--- a/Section_I/law12.tex
+++ b/Section_I/law12.tex
@@ -120,14 +120,14 @@ The indirect free kick is taken from the place where the offence occurred (see L
 \headlinebox
 
 The yellow card is used to communicate that a player, substitute or substituted player has been cautioned.
-
+\added{The Technical Committee may use yellow cards to communicate that a team has been cautioned.}
 \bigskip
 
 The red card is used to communicate that a player, substitute or substituted player has been sent off.
-
+\added{The Technical Committee may use red cards to communicate that a team has been excluded from the tournament.}
 \bigskip
 
-Only a player, substitute or substituted player may be shown the red or yellow card.
+Only \added{a team, }a player, substitute or substituted player may be shown the red or yellow card.
 
 \bigskip
 
@@ -135,7 +135,7 @@ The referee has the authority to take disciplinary sanctions from the moment he 
 
 \bigskip
 
-A player who commits a cautionable or sending-off offence, either on or off the field of play, whether directed towards an opponent, a team-mate, the referee, an assistant referee or any other person, is disciplined according to the nature of the offence committed.
+A player who \added{or a team that }commits a cautionable or sending-off offence, either on or off the field of play, whether directed towards an opponent, a team-mate, the referee, an assistant referee or any other person, is disciplined according to the nature of the offence committed.
 
 \bigskip
 

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -481,11 +481,27 @@ The team who would have kicked off if the timeout had not been called shall kick
 
 \bigskip
 
-{\bfseries Disciplinary sanctions}
+{\bfseries Disciplinary sanctions\added{ against robots}}
 
 Yellow and red cards given to robots only accumulate for the current game and are cleared again after the end of each game. Warnings against robot handlers and/or teams have to be reported to the Technical Committee after each game. They are recorded and accumulated for the whole tournament. 
 
+\added{
 
+\bigskip
+
+{\bfseries Disciplinary sanctions against teams}
+
+\added{A team is cautioned by the technical committee and may be shown a yellow
+  card if it commits any of the following offences:
+}
+
+\begin{itemize}
+\item \added{unsporting behaviour}
+\item \added{dissent by word or action}
+\item \added{persistent infringement of the Laws of the Game}
+\item \added{delaying the restart of play}
+\end{itemize}
+}
 
 
 \bigskip


### PR DESCRIPTION
In the physical competition, yellow and red cards can only be awarded to robots and to robot handlers. For the virtual competition, we added some cases in which it could be awarded to an entire team. This could be transferred to the physical competition as well.