### PR TITLE
vote12-1: Penalty kick with goalkeeper on or behind goal line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.pdf
 *.out
 *.toc
+RCHL-2020-Rules.fdb_latexmk
+RCHL-2020-Rules.fls
+RCHL-2020-Rules.synctex.gz

--- a/Section_I/law14.tex
+++ b/Section_I/law14.tex
@@ -38,7 +38,7 @@ The ball:
 The defending goalkeeper:
 
 \begin{itemize}
-\item must remain on his goal line\added{ or behind it},\removed{ facing the kicker,} between the goalposts until the ball has been kicked 
+\item must remain on his goal line\added{ or behind it}, facing the kicker, between the goalposts until the ball has been kicked 
 \end{itemize}
 
 The players other than the kicker must be:

--- a/Section_I/law14.tex
+++ b/Section_I/law14.tex
@@ -38,7 +38,7 @@ The ball:
 The defending goalkeeper:
 
 \begin{itemize}
-\item must remain on his goal line, facing the kicker, between the goalposts until the ball has been kicked 
+\item must remain on his goal line\added{ or behind it},\removed{ facing the kicker,} between the goalposts until the ball has been kicked 
 \end{itemize}
 
 The players other than the kicker must be:


### PR DESCRIPTION
For the virtual competition, we allowed the goalkeeper to position themselves on or behind the goal line. In the physical competition, the goalkeeper has to be on the goal line. However, in the physical competition, the goalkeeper has to face towards the front, while in the virtual competition this constraint was removed. The proposal would be to use the new rules for the virtual competition in the physical competition as well.