### PR TITLE
vote13: Throw-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.pdf
 *.out
 *.toc
+RCHL-2020-Rules.fdb_latexmk
+RCHL-2020-Rules.fls
+RCHL-2020-Rules.synctex.gz

--- a/Section_I/law15.tex
+++ b/Section_I/law15.tex
@@ -46,13 +46,19 @@ Robots are also allowed to perform the throw-in with their hands, in this case:
 \greyed{(replaces: At the moment of delivering the ball, the thrower:)}
 
 \begin{itemize}
-\item faces the field of play
+\item \removed{faces the field of play}
 \item has part of each foot either on the touch line or on the ground outside
       the touch line
-\item holds the ball with both hands
-\item delivers the ball from behind and over his head
-\item \greyed{(suspended: delivers the ball from the point where it left the field of play)}
+\item holds the ball with \removed{both hands} \added{at least one hand}
+\item \removed{delivers the ball from behind and over his head}
+\greyed{\item (suspended: delivers the ball from the point where it left the field of play)}
+\item \added{releases the ball within 10 seconds}
 \end{itemize}
+
+\added{
+If a robot tries to perform a throw-in with hands and fails to respect the
+rules, a free-kick is awarded to the opponent team.
+}
 
 \bigskip
 


### PR DESCRIPTION
The throw-in procedure was modified for the virtual competition. In particular, the robot does not need to face towards the field, it does not need to use two hands, it does not need to lift the ball above the head and it has a maximum of 10 seconds to execute the throw-in once the ball is lifted. The proposal would be to use the new rules for the virtual competition for the physical competition as well.