### PR TITLE
vote18: Whistle recognition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 *.pdf
 *.out
 *.toc
+RCHL-2020-Rules.fdb_latexmk
+RCHL-2020-Rules.fls
+RCHL-2020-Rules.synctex.gz

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -233,7 +233,7 @@ A team that forfeits is disqualified from the competition. Forfeiting is defined
       blows the whistle) will be penalized.}
 \item The opponents of the team taking the kick-off are outside the centre circle until the ball is in play.
 \item The ball is stationary on the centre mark. 
-\item The referee \removed{gives the signal ``PLAY'' or} whistles\added{ and after 15 seconds gives the signal ``PLAY''}.
+\item The referee gives the signal ``PLAY''\added{ in Virtual competition} or whistles\added{ and after 15 seconds gives the signal ``PLAY'' in real competition}.
 \item The ball is in play when it is kicked and clearly moves as determined by
       the referee or 10 seconds elapsed after the signal.
 \end{itemize}
@@ -279,7 +279,7 @@ the centre line and outside of the centre circle and the ball is in play. This r
 \begin{enumerate}
       \item State is set to SET
       \item The referee waits from 15 to 30 seconds before sending signals to start the trial
-      \item The referee whistles and after 15 seconds gives the signal ``PLAY''
+      \item The referee gives the signal ``PLAY'' in Virtual competition or whistles and after 15 seconds gives the signal ``PLAY'' in real competition
       \item If the robot begins moving its legs or moves in any fashion during the set 
       (i. e. before the referee blows the whistle), the trial ends immediately
 \end{enumerate}

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -229,10 +229,11 @@ A team that forfeits is disqualified from the competition. Forfeiting is defined
       on the touch line close to the penalty mark of the respective team's side,
       facing the opposite touch line, to enter the field from there upon the ``PLAY'' signal.}
       Illegally positioned players do not suffer a removal penalty and are
-      allowed to enter the field as soon as the game starts.
+      allowed to enter the field as soon as the game starts.\added{ Robots that begin moving their legs or move in any fashion during set (i. e. before the referee
+      blows the whistle) will be penalized.}
 \item The opponents of the team taking the kick-off are outside the centre circle until the ball is in play.
 \item The ball is stationary on the centre mark. 
-\item The referee gives the signal ``PLAY'' or whistles.
+\item The referee \removed{gives the signal ``PLAY'' or} whistles\added{ and after 15 seconds gives the signal ``PLAY''}.
 \item The ball is in play when it is kicked and clearly moves as determined by
       the referee or 10 seconds elapsed after the signal.
 \end{itemize}
@@ -272,7 +273,19 @@ allowed to locomote. If such a team has kick-off then at the signal ``PLAY'' the
 the centre line and outside of the centre circle and the ball is in play. This rule does not apply if the referee box is out of commission.}
 
 \bigskip
+\added{
+{\bfseries Penalty shoot-outs procedure}
 
+\begin{enumerate}
+      \item State is set to SET
+      \item The referee waits from 15 to 30 seconds before sending signals to start the trial
+      \item The referee whistles and after 15 seconds gives the signal ``PLAY''
+      \item If the robot begins moving its legs or moves in any fashion during the set 
+      (i. e. before the referee blows the whistle), the trial ends immediately
+\end{enumerate}
+
+\bigskip
+}
 
 {\bfseries Free-kick procedure}
 


### PR DESCRIPTION
Whistle recognition:

Add whistle blowing recognition for kick-off procedure similar to one implemented in SPL rules:
The referee will announce the start of the Playing state with a single whistle blow. The GameController Playing signal will be delayed by 15. This delay applies to both kick-off and penalty
shots.

