### PR TITLE
vote19, Variant 2: Game timer must not be stopped

### DIFF
--- a/Section_I/law7.tex
+++ b/Section_I/law7.tex
@@ -67,3 +67,13 @@ If a penalty kick has to be taken or retaken, the duration of either half is ext
 \headlinebox
 
 An abandoned match is replayed unless the competition rules provide otherwise.
+
+\bigskip
+
+\added{
+{\bfseries Set and Ready states}
+
+\headlinebox
+
+During the Set and Ready states, the game clock should not be stopped in both knock-out and round-robin games.
+}


### PR DESCRIPTION
Game timer 

State Ready time is 45 seconds, State Set time is 5 seconds. Together 50 seconds for each kick-off are included into overall game time during round robin games. But in knockout games 50 seconds for each kick-off are excluded from overall game time, means overall game time counter is suspended for State Ready and State Set by Game Controller. This seems to be not logic.


