### PR TITLE
Voting 2025-3-declined

### DIFF
--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -63,7 +63,7 @@ league organizing committee.
 The competitions consist of:
 
 \begin{enumerate}
-\item Regular tournament for KidSize (4 vs. 4),
+\item Regular tournament for KidSize \removed{(4 vs. 4)}\added{(8 vs. 8)},
 \item Regular tournament for AdultSize (2 vs. 2),
 \item Drop-In games for KidSize and AdultSize (physical competition only)
 \item Technical challenges (physical competition only).
@@ -614,13 +614,13 @@ Some teams might play one more Drop-In game than others.
 
 All normal game rules apply to this competition. The only exceptions are:
 \begin{enumerate}
-\item The games are played with 5 players in a KidSize team
+\item The games are played with \removed{5}\added{8} players in a KidSize team
      and 3 players in an AdultSize team.
       If there is an insufficient number of participants,
-      games may be played 4 vs. 4 or 3 vs. 3 for KidSize
+      games may be played \added{7 vs. 7 or 6 vs. 6 or 5 vs. 5 or }4 vs. 4 or 3 vs. 3 for KidSize
       or 2 vs. 2 for AdultSize.
 \item Games may end in a draw.
-\item Each of the players has a jersey number from the set {1, 2, 3, 4, 5},
+\item Each of the players has a jersey number from the set {1, 2, 3, 4, 5\added{, 6, 7, 8}},
       resp. {1, 2, 3}.
 \item Drop-in teams will wear the blue and red team colours.
 \item In AdultSize, one robot handler per competing robot is allowed.


### PR DESCRIPTION
SQ222
 Larger drop-in games for Kid Size

Kid size drop-in games should be played as 8v8 on the adult-size field.

This would result in fewer total games needed for all players to participate and encourage team play, as the distances involved for kid size require cooperation.