### PR TITLE
Voting 2025-4-accepted

### DIFF
--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -111,7 +111,7 @@ All robots participating in the Humanoid League must comply with the following r
 \item The robot does not possess a configuration where it is extended longer than 1.5{\textperiodcentered}$H_{top}$ .
 \item The length of the legs $H_{leg}$, including the feet, satisfies 0.35{\textperiodcentered}$H_{top}$ ${\leq}$ $H_{leg}$ ${\leq}$ 0.7{\textperiodcentered}$H_{top}$ .
 \item The height of the head $H_{head}$, including the neck,
-  satisfies $0.1 \cdot H_{top} \sleq H_{head} \leq 0.3 \cdot H_{top}$.
+  satisfies $0.1 \cdot H_{top} \leq H_{head} \leq 0.3 \cdot H_{top}$.
   $H_{head}$ is defined as the vertical distance from the axis of the first arm
   joint at the shoulder to the top of the head.
 \item The leg length is measured while the robot is standing up straight. The length is measured from the first rotating joint where its axis lies in the plane parallel to the standing ground to the tip of the foot.

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -692,11 +692,13 @@ Assuming teams with player 1 to score a single goal in every game (with player 1
 The technical challenges consist of:
 
 \begin{enumerate}
-\item Push Recovery \removed{(AdultSize)}\added{(KidSize and AdultSize)}
-\item Collaborative Localization \removed{(KidSize)}\added{(KidSize and AdultSize)}
-\item Goal Kick from Moving Ball (KidSize and AdultSize)
-\item Parkour (KidSize and AdultSize)
-\item High-Kick (KidSize and AdultSize)
+\item Push Recovery \removed{(AdultSize)}
+\item Collaborative Localization \removed{(KidSize)}
+\item Goal Kick from Moving Ball \removed{(KidSize and AdultSize)}
+\item Parkour \removed{(KidSize and AdultSize)}
+\item High-Kick \removed{(KidSize and AdultSize)}
+\item \added{Obstacle Navigation}
+\item \added{Long Stride}
 \end{enumerate}
 
 For details on the technical challenges, please refer to Section III of this document.

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -679,8 +679,8 @@ Assuming teams with player 1 to score a single goal in every game (with player 1
 The technical challenges consist of:
 
 \begin{enumerate}
-\item Push Recovery (AdultSize)
-\item Collaborative Localization (KidSize)
+\item Push Recovery \removed{(AdultSize)}\added{(KidSize and AdultSize)}
+\item Collaborative Localization \removed{(KidSize)}\added{(KidSize and AdultSize)}
 \item Goal Kick from Moving Ball (KidSize and AdultSize)
 \item Parkour (KidSize and AdultSize)
 \item High-Kick (KidSize and AdultSize)

--- a/Section_III/collaborative-localization.tex
+++ b/Section_III/collaborative-localization.tex
@@ -1,9 +1,9 @@
 \clearpage
 \sffamily
 {\bfseries\color[rgb]{0.4,0.4,0.4} Part B: Collaborative Localization
-  (KidSize only)}
+  \removed{(KidSize only)}}
 \phantomsection
-\addcontentsline{toc}{subsection}{Part B: Collaborative Localization (KidSize only)}
+\addcontentsline{toc}{subsection}{Part B: Collaborative Localization \removed{(KidSize only)}}
 
 
 \bigskip

--- a/Section_III/general-rules.tex
+++ b/Section_III/general-rules.tex
@@ -39,7 +39,7 @@ The team scheduled for the Technical Challenge must have access to the field fiv
  
 The Technical Challenge consists of \removed{four parts:
   B, C, D and E for KidSize and
-  A, C, D and E for AdultSize.}\added{five parts: A, B, C, D, E.}
+  A, C, D and E for AdultSize.}\added{seven parts: A, B, C, D, E, F, G.}
 Each of the parts can be attempted multiple times, in any order.
 The team might terminate a trial at any time,
 in order to reattempt the same part or switch to another part of the challenge.

--- a/Section_III/general-rules.tex
+++ b/Section_III/general-rules.tex
@@ -10,8 +10,8 @@ General Rules for Technical Challenges}
 The technical challenges consist of the following individual challenges:
 
 \begin{itemize}
-\item Part A: Push Recovery (AdultSize)
-\item Part B: Collaborative Localization (KidSize)
+\item Part A: Push Recovery \removed{(AdultSize)}
+\item Part B: Collaborative Localization \removed{(KidSize)}
 \item Part C: Goal Kick from Moving Ball
 \item Part D: Parkour
 \item Part E: High Kick
@@ -35,9 +35,9 @@ The team scheduled for the Technical Challenge must have access to the field fiv
 
 \headlinebox
  
-The Technical Challenge consists of four parts:
+The Technical Challenge consists of \removed{four parts:
   B, C, D and E for KidSize and
-  A, C, D and E for AdultSize.
+  A, C, D and E for AdultSize.}\added{five parts: A, B, C, D, E.}
 Each of the parts can be attempted multiple times, in any order.
 The team might terminate a trial at any time,
 in order to reattempt the same part or switch to another part of the challenge.

--- a/Section_III/push-recovery.tex
+++ b/Section_III/push-recovery.tex
@@ -1,9 +1,9 @@
 \clearpage
 \sffamily
 {\bfseries\color[rgb]{0.4,0.4,0.4}
-Part A: Push Recovery (AdultSize only)}
+Part A: Push Recovery \removed{(AdultSize only)}}
 \phantomsection
-\addcontentsline{toc}{subsection}{Part A: Push Recovery (AdultSize only)}
+\addcontentsline{toc}{subsection}{Part A: Push Recovery \removed{(AdultSize only)}}
 
 
 \bigskip


### PR DESCRIPTION

Remove limitations for sub leagues for technical challenges

Remove the limitation that technical challenges can only be completed by Kid Size or Adult Size robots.

Some current technical challenges state that they only apply to Kid Size or Adult Size; however, the skills involved apply to robots from either league.

This limitation should be removed for all current technical challenges, and future challenges that make sense for both leagues should be allowed to be completed by either league.