### PR TITLE
Voting 2025-7

### DIFF
--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -49,7 +49,7 @@ All actions of the robots must be kinematically equivalent to humanoid motions.
 
 \bigskip
 
-Robots competing in the physical competition must be equipped with an emergency stop button that makes the robot immediately desist with all motions, or ideally go limp and/or cut power to the actuators. In addition to the emergency stop button, robots may only have up to two additional physical or virtual buttons: One to start the robot behaviour and one to stop the behaviour. The buttons must be clearly labeled. If the robot has more buttons that cannot be detached, they must be visibly masked during the games.
+Robots competing in the physical competition must be equipped with an emergency stop button that makes the robot immediately desist with all motions, or ideally go limp and/or cut power to the actuators. In addition to the emergency stop button, robots may only have up to two additional physical or virtual buttons: One to start the robot behaviour and one to stop the behaviour. The buttons must be clearly labeled. If the robot has more buttons that cannot be detached, they must be visibly masked during the games.\added{ Emergency stop button must be in conformity with ISO10218 rules.}
 Body parts of robots competing in the virtual competition that are considered feet and arms must be marked in the virtual robot models.
 
 \bigskip


### PR DESCRIPTION
SQ940
Emergency stop buttons following ISO10218 rules

It was proposed that emergency stop buttons on robots should follow the ISO10218 rules for emergency stop buttons. One concern with this proposal is how to provide access to the ISO standard to all teams.  There is only one legal way to obtain rules – each team has to buy them from ISO organization. Nevertheless the general consensus seems to be that the current emergency stop rules are not sufficient.
Voting can be for adding requirement to follow ISO10218 rules or against adding any changes to requirements or request to Technical Committee to develop Robocup guidelines to Emergency Buttons which must be free of charge.  