### PR TITLE
Voting 2025-8-002

### DIFF
--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -265,10 +265,11 @@ The basic compulsory equipment of a player comprises the following separate item
   robot must be of solid shape appearance.
 \item \simplify{(new) }The robots must be marked with team markers.
       These markers are coloured red for one team and blue for the other team.
-      The total visible area of all team markers (up to 20) on the robot's arms,
+     \added{Robots must have one single solid rectangular marker in front and one in back of body. Area of each marker must be not less than $0.03\cdot {H_{top}}^2$. Theam can choose to wear t-shirt/jersey instead of rectangular marker to determine their team color.}
+      \removed{The total visible area of all team markers (up to 20) on the robot's arms,
       legs and chest combined must be at least $0.06\cdot {H_{top}}^2$.
       The visible area of the one to five largest team markers on each side
-      (left, right, front and back) must be at least $0.015\cdot {H_{top}}^2$.
+      (left, right, front and back) must be at least $0.015\cdot {H_{top}}^2$.}
       The team that during the first half plays the left side of the field (as viewed from the game controller table) plays in red, the team that plays the right side plays in blue.
       In the virtual competition, the color teams play in is randomly assigned and announced in the game plan.
 

--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -265,7 +265,7 @@ The basic compulsory equipment of a player comprises the following separate item
   robot must be of solid shape appearance.
 \item \simplify{(new) }The robots must be marked with team markers.
       These markers are coloured red for one team and blue for the other team.
-     \added{Robots must have one single solid rectangular marker in front and one in back of body. Area of each marker must be not less than $0.03\cdot {H_{top}}^2$. Theam can choose to wear t-shirt/jersey instead of rectangular marker to determine their team color.}
+     \added{Robots must have one single solid rectangular marker in front and one in back of body. Area of each marker must be not less than $0.02\cdot {H_{top}}^2$. Theam can choose to wear t-shirt/jersey instead of rectangular marker to determine their team color.}
       \removed{The total visible area of all team markers (up to 20) on the robot's arms,
       legs and chest combined must be at least $0.06\cdot {H_{top}}^2$.
       The visible area of the one to five largest team markers on each side

--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -265,7 +265,7 @@ The basic compulsory equipment of a player comprises the following separate item
   robot must be of solid shape appearance.
 \item \simplify{(new) }The robots must be marked with team markers.
       These markers are coloured red for one team and blue for the other team.
-     \added{Robots must have one single solid rectangular marker in front and one in back of body. Area of each marker must be not less than $0.02\cdot {H_{top}}^2$. Theam can choose to wear t-shirt/jersey instead of rectangular marker to determine their team color.}
+     \added{Robots must have one single solid rectangular marker in front and one in back of body. Area of each marker must be not less than $0.03\cdot {H_{top}}^2$. Theam can choose to wear t-shirt/jersey instead of rectangular marker to determine their team color.}
       \removed{The total visible area of all team markers (up to 20) on the robot's arms,
       legs and chest combined must be at least $0.06\cdot {H_{top}}^2$.
       The visible area of the one to five largest team markers on each side


### PR DESCRIPTION
SQ137
Team color rules should require a single solid marker or t-shirt/jersey

Currently, a robot's color is determined by the area of the individual markers.
This makes it difficult during robot inspection to measure a lot of small individual pieces.
It was proposed that robots should be required to have a single solid marker per side or a t-shirt/jersey to determine their team color.
Current PR specifies size of marker 0.02* H2
