### PR TITLE
Voting 2025-11-accepted

### DIFF
--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -419,7 +419,8 @@ A player that stays outside of the artificial turf for 20 seconds is
  
 {\bfseries Damage to the Field}
 
-A robot that damages the field, or poses a threat to spectator safety, will be removed from the field for a 30 second removal penalty.
+A robot that damages the field, or poses a threat to spectator safety, will be removed from the field for a 30 second removal penalty.\added{
+It is prohibited to use cranes or gantries on field, even in the free time between games.}
 
 \bigskip
 


### PR DESCRIPTION
SQ319
Ban for cranes or gantries on field. 
During RoboCup, it was proposed to ban cranes and gantries for carrying robots from the adult size field, even in the free time between games. Key arguments for this ban were the public getting a negative impression of the league and a push towards more robot autonomy. Key arguments against were safety concerns and the fact that it makes working on robots for longer times easier.

It was also discussed whether the gantries may cause damage to the fields, but teams confirmed that this is not the case.