### PR TITLE
Voting 2025-12-accepted

### DIFF
--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -199,7 +199,7 @@ Teams have to be able to use the referee box in order to respect the rules.
 
 \bigskip
 
-In KidSize, no humans are allowed on the field while the
+\removed{In KidSize, no}\added{No} humans are allowed on the field while the
 ball is in play.
 During a phyiscal game, robot handlers stay in a designated area and must receive permission from the
 referee prior to entering the field.

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -153,15 +153,15 @@ receives zero points.
 
 \bigskip
 
-For the AdultSize soccer games of a physical competiton, a specific rule for robot handlers applies. For every robot, one robot handler is allowed to stay near the robot such that the robot handler does not interfere with the game. Specifically, the robot handler:
+\removed{For the AdultSize soccer games of a physical competiton, a specific rule for robot handlers applies. For every robot, one robot handler is allowed to stay near the robot such that the robot handler does not interfere with the game. Specifically, the robot handler:}
 \begin{itemize}
-\item should position himself behind the robot at a distance of at least an arm length away from the robot's convex hull.
-\item must not block the vision of any of the robots on the ball or goals.
-\item must not block the path of any robot.
-\item must not touch any robot. Touching a robot is considered an offence that is penalised by a removal penalty of the robot handler's own robot according to the laws of the game.
-\item must not enter the radius of one arm length around the robot unless the robot is to be picked up or to avoid interference with the game. Violation of this rule results in a warning to the respective robot handler. After two warnings, the robot handler needs to be replaced similarly to the rule specified under ``Request for Pick-up''.
-\item has to be dressed in black clothes.
-\item may not communicate with the robot in any way, including verbally, while the robot is in play.
+\item \removed{should position himself behind the robot at a distance of at least an arm length away from the robot's convex hull.}
+\item \removed{must not block the vision of any of the robots on the ball or goals.}
+\item \removed{must not block the path of any robot.}
+\item \removed{must not touch any robot. Touching a robot is considered an offence that is penalised by a removal penalty of the robot handler's own robot according to the laws of the game.}
+\item \removed{must not enter the radius of one arm length around the robot unless the robot is to be picked up or to avoid interference with the game. Violation of this rule results in a warning to the respective robot handler. After two warnings, the robot handler needs to be replaced similarly to the rule specified under ``Request for Pick-up''.}
+\item \removed{has to be dressed in black clothes.}
+\item \removed{may not communicate with the robot in any way, including verbally, while the robot is in play.}
 \end{itemize}
 \color{black}
 


### PR DESCRIPTION
SQ921
Remove adult-size robot handlers from the field

Remove robot handlers from the adult-size field during normal games.
Robot handlers should enter the field only when the robots require assistance.