### PR TITLE
Voting 2025-13-accepted

### DIFF
--- a/Section_I/law13.tex
+++ b/Section_I/law13.tex
@@ -105,7 +105,7 @@ Players are guaranteed at least 15 seconds to move away from the ball.
 They may take up to 30 seconds if the team taking the free kick has not
 announced their robot is ready to take the kick off.
 Any opponent robot still illegally positioned is considered as an incapable
-player and must be removed from the field for 30 seconds removal penalty.
+player and must be removed from the field for \removed{30}\added{10} seconds removal penalty.
 The referee may decide to execute the free kick before 15 seconds have passed if
 the team taking the free kick have announced their robot is ready and if no
 opponent is illegally positioned.
@@ -120,7 +120,7 @@ Once the free kick can be executed, the referee blows the whistle (physical comp
 If, when a free kick is taken, an opponent is closer to the ball than the required distance:
 
 \begin{itemize}
-\item the opponent receives a 30 second removal penalty \greyed{(replaces: the kick is retaken)}
+\item the opponent receives a \removed{30}\added{10} second removal penalty \greyed{(replaces: the kick is retaken)}
 \end{itemize}
 
 

--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -177,7 +177,7 @@ handler attempts to service the robot again.
 
 
 Teams may not use any type of communication
-with robots in play, in service or with robots serving their 30 seconds penalty
+with robots in play, in service or with robots serving their \removed{30}\added{10} seconds penalty
 time that contains information which reduces the need for autonomy in detecting
 the current game state of the robots, including the position of the ball,
 the location where the robot re-enters the field,

--- a/Section_I/procedure.tex
+++ b/Section_I/procedure.tex
@@ -45,7 +45,7 @@ Procedure
 \item With the exception of the foregoing case,
       only players who are on the field of play at the end of the match in a physical competition,
       which includes extra time where appropriate,
-      \simplify{(new) }or which are serving their 30 second penalty time or are currently in service,
+      \simplify{(new) }or which are serving their \removed{30}\added{10} second penalty time or are currently in service,
       are eligible to take kicks from the penalty mark
 
 \greyed{\item (suspended: Each kick is taken by a different player and all eligible players must take a kick before any player can take a second kick)}

--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -327,7 +327,7 @@ For KidSize, $D$ is 50 centimeters and for AdultSize, $D$ is 1 meter.
       if the team taking the game interruption has
       announced their robot is ready and if no opponent is illegally positioned.
 \item Any opponent robot still illegally positioned is considered as an
-      incapable player and must be removed from the field for 30 seconds
+      incapable player and must be removed from the field for \removed{30}\added{10} seconds
       removal penalty.
 \item When the referee decides to execute the game interruption
       and all opponent robots are
@@ -405,21 +405,21 @@ It is up to the referee to judge whether a player is capable of play.
 In the physical competition, the referee may ask the team leader of a player suspected to be incapable of
 play to demonstrate playing ability at any time.
 A field player that is not able to get back into a standing or walking
-posture from a fall within 20 seconds receives a 30
+posture from a fall within 20 seconds receives a \removed{30}\added{10}
 seconds removal penalty.
 If the ball is within a radius of 0.5 m around the goal keeper inside the goal area,
 the goal keeper has to show active attempts to move the ball out of this radius by walking towards the ball or moving the ball.
 If no attempt is shown for 20 seconds, the goal keeper is considered to be an
-inactive player and receives a 30 seconds removal penalty.
+inactive player and receives a \removed{30}\added{10} seconds removal penalty.
 
 A player that stays outside of the artificial turf for 20 seconds is
-  considered as an incapable player and receives a 30 seconds removal penalty.
+  considered as an incapable player and receives a \removed{30}\added{10} seconds removal penalty.
 
 \bigskip
  
 {\bfseries Damage to the Field}
 
-A robot that damages the field, or poses a threat to spectator safety, will be removed from the field for a 30 second removal penalty.
+A robot that damages the field, or poses a threat to spectator safety, will be removed from the field for a \removed{30}\added{10} second removal penalty.
 
 \bigskip
 
@@ -444,7 +444,7 @@ Servicing robots on the playing field is not permitted.
 A robot may be taken out of the field for service,
 after receiving permission from the referee.
 Taking out a robot for service does not count as a substitution.
-A serviced robot may not come into play again before 30 seconds elapsed after it
+A serviced robot may not come into play again before \removed{30}\added{10} seconds elapsed after it
 was taken out.
 It has to enter the field from the team's own half of the field close to the
 penalty mark facing the opposite touch line, as indicated by the referee.
@@ -463,7 +463,7 @@ significant changes to robot positions or heading directions. Untangled robots m
 {\bfseries Removal Penalty}
 
 \begin{itemize}
-\item Time penalties of 30 seconds for players are called by the referee. When a penalty is called in the physical competition, the designated robot handler has to remove the robot as soon as possible and by that interacting as little as possible with the game
+\item Time penalties of \removed{30}\added{10} seconds for players are called by the referee. When a penalty is called in the physical competition, the designated robot handler has to remove the robot as soon as possible and by that interacting as little as possible with the game
 \item In the physical competition, the referee and assistant referees are in charge of timing the penalties and notifying the teams to put back their robots to play. In the virtual competition, the robots receive the signal that their penalty time is over automatically from the GameController.
 \item A field player or goal keeper suffering a time penalty will be
   removed from the field and is only allowed to re-enter
@@ -487,11 +487,11 @@ significant changes to robot positions or heading directions. Untangled robots m
 \item In the physical competition, after the robot has been placed at the position indicated by the referee
       and with both feet entirely outside the field of play the robot handler
       announces to the assistant referee that the robot is ready to get back in.
-      The 30 seconds penalty start counting from the point of announcement.
+      The \removed{30}\added{10} seconds penalty start counting from the point of announcement.
       From this point onwards the robot handler may not touch or interfere with
       the robot in any other way (including button presses).
       If any part of the robot touches the field of play (including touch lines)
-      or the robot handler touching the robot before the 30 seconds expired,
+      or the robot handler touching the robot before the \removed{30}\added{10} seconds expired,
       the time is reset. In the virtual competition, the penalty time starts counting immediately after the robot was repositioned to the side line by the autonomous referee.
 \item The GameController or the assistant referee operating it will:
   \begin{itemize}
@@ -501,7 +501,7 @@ significant changes to robot positions or heading directions. Untangled robots m
   \item In the physical competition, the assistant referee resets the penalty time whenever the robot handler touches the robot or
       the robot touches the field of play
   \end{itemize}
-\item The penalty is automatically removed after 30 seconds of penalty have expired.
+\item The penalty is automatically removed after \removed{30}\added{10} seconds of penalty have expired.
 \end{itemize}
 
 \bigskip


### PR DESCRIPTION
SQ492
Shorter penalization time.
In the current RoboCup competitions, it is common for robots to be penalized (e.g., for infractions like pickups), leading to periods where only one team's robots remain on the field. This situation not only reduces the competitive balance but also diminishes the overall excitement and engagement of the match.
It is proposed a shorter penalty duration  (10s), to allow quicker reintegration of robots, having a more interesting game being played.