### PR TITLE
Voting 2025-14-2-declined

### DIFF
--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -652,6 +652,8 @@ Referees for a match may be picked among the pool of available referees from any
 
 When a goal is scored, all players of the scoring team on the field receive 1 point and the player who scored the goal receives an additional 1 point if it was not an own goal. A robot is considered to be on the field if both feet of the robot are fully inside the field area. The player who scored the goal receives the points regardless of its position on the field. Incapable players, penalized players, players outside the field or players having been removed for any other reason, e.g. service, will receive no point. When a goal is suffered, all players of the team suffering the goal receive -1 points, including incapable players, penalized players or players having been removed for any other reason, e.g. in service. Points from all games are summed up. For players who played one or more games more than the others, only the points of those games with the higher scores are considered.
 
+\added{During throw-in procedure if a thrower uses his hands for entering the ball into the game and as a result of throw-in the goal was scored to the goals of the throwers opponent after the ball was touched by any other player, the thrower receives advantage which is evaluated in form of additional points to robots score. Advantage is valid if the goal was scored before the next Game interruption procedure occurs. The thrower receives additional 2 point for successful throw-in advantage.}
+
 Drop-in players are initially ranked according to the arithmetic mean.
 If there are ties, the tied players are ranked according to the number of games played,
 the maximum points awarded in a single game and the number of goals scored (in


### PR DESCRIPTION


SQ314
These proposals are intended to encourage the use of hands when performing throwing, until it becomes more common. (Drop-in games, Law 15 - The Throw-In in RC-HL-2024 Rules.)

In Drop-in games:
During throw-in procedure if a thrower uses hands for entering the ball into game and as result of throw-in the goal was scored to the goals of the thrower’s opponent after the ball was touched by any other player, the thrower receives advantage which is evaluated in form of additional points to robot’s score. Advantage is valid if the goal was scored before the next Game interruption procedure occurs.

Proposal 2: The thrower receives additional 2 point for successful throw-in advantage.
