### PR TITLE
Voting 2025-15-1-declined

### DIFF
--- a/Section_III/obstacle_navigation.tex
+++ b/Section_III/obstacle_navigation.tex
@@ -26,7 +26,7 @@ The width of the field strip $X$ is 1.5m for KidSize and 3m for AdultSize. The l
 
 Five obstacles are placed on the field. The obstacles are blue or red as specified by the team colors. Their height is 0.4m for KidSize and 1m for AdultSize. Their width is 0.4m for KidSize and 0.6m for AdultSize.
 
-Nine locations are possible for obstacle placement at increments of $\frac{1}{4}$ X and B respectively. Not more than two obstacles shall be placed next to each other (i.e. at the same $\frac{1}{4}$ increment of B) to allow the robot to pass. The placement and color of obstacles shall be randomized for each attempt using for example the roll of a dice and/or a coin flip.
+Nine locations are possible for obstacle placement at increments of $\frac{1}{4}$ X and B respectively. Not more than two obstacles shall be placed next to each other (i.e. at the same $\frac{1}{4}$ increment of B) to allow the robot to pass. The placement and color of obstacles shall be randomized for each attempt using for example the roll of a dice and/or a coin flip.\added{ Additional two obstacles must be placed on lines at left and right side.} 
 
 \vspace{2em}
 {\bfseries Execution}


### PR DESCRIPTION
SQ853
This discussion deals with enhancing the Partial success or Success conditions of
Technical Challenge Part F: Obstacle Navigation Challenge In the RC-HL-2024 Rules.
The following are additional suggestions to prevent scoring when the robot walks straight to the sideline while stepping on the lines on both sides:

Setup A: Two of the Obstacles must be attached to the lines on both sides.

In the case of Setup A, this completely excludes the situation where the robot passes while stepping on the lines on the outside of obstacle. This is a strict restriction because it infringes on the freedom of the team’s robot to complete the field.
