### PR TITLE
Voting 2025-15-2-declined

### DIFF
--- a/Section_III/obstacle_navigation.tex
+++ b/Section_III/obstacle_navigation.tex
@@ -24,7 +24,7 @@ A section of the field (marked dashed in yellow) is partitioned of using white t
 
 The width of the field strip $X$ is 1.5m for KidSize and 3m for AdultSize. The length of the field strip $B$ is defined by the field sizes of KidSize and AdultSize.
 
-Five obstacles are placed on the field. The obstacles are blue or red as specified by the team colors. Their height is 0.4m for KidSize and 1m for AdultSize. Their width is 0.4m for KidSize and 0.6m for AdultSize.
+Five obstacles are placed on the field. The obstacles are blue or red as specified by the team colors. Their height is 0.4m for KidSize and 1m for AdultSize. \removed{Their width is 0.4m for KidSize and 0.6m for AdultSize}\added{The width of obstacles must be narrower than width of robot}.
 
 Nine locations are possible for obstacle placement at increments of $\frac{1}{4}$ X and B respectively. Not more than two obstacles shall be placed next to each other (i.e. at the same $\frac{1}{4}$ increment of B) to allow the robot to pass. The placement and color of obstacles shall be randomized for each attempt using for example the roll of a dice and/or a coin flip.
 

--- a/Section_III/obstacle_navigation.tex
+++ b/Section_III/obstacle_navigation.tex
@@ -5,7 +5,6 @@
 \addcontentsline{toc}{subsection}{Part F: Obstacle Navigation Challenge}
 
 \bigskip
-\added{
 \begin{figure}[h!]
 \centering
 \includegraphics[width=\linewidth]{img/tcnavigation.png}
@@ -24,9 +23,9 @@ A section of the field (marked dashed in yellow) is partitioned of using white t
 
 The width of the field strip $X$ is 1.5m for KidSize and 3m for AdultSize. The length of the field strip $B$ is defined by the field sizes of KidSize and AdultSize.
 
-Five obstacles are placed on the field. The obstacles are blue or red as specified by the team colors. Their height is 0.4m for KidSize and 1m for AdultSize. \removed{Their width is 0.4m for KidSize and 0.6m for AdultSize}\added{The width of obstacles must be narrower than width of robot}.
+Five obstacles are placed on the field. The obstacles are blue or red as specified by the team colors. Their height is 0.4m for KidSize and 1m for AdultSize. Their width is 0.4m for KidSize and 0.6m for AdultSize.
 
-Nine locations are possible for obstacle placement at increments of $\frac{1}{4}$ X and B respectively. Not more than two obstacles shall be placed next to each other (i.e. at the same $\frac{1}{4}$ increment of B) to allow the robot to pass. The placement and color of obstacles shall be randomized for each attempt using for example the roll of a dice and/or a coin flip.
+Nine locations are possible for obstacle placement at increments of $\frac{1}{4}$ X and B respectively. Not more than two obstacles shall be placed next to each other (i.e. at the same $\frac{1}{4}$ increment of B) to allow the robot to pass. The placement and color of obstacles shall be randomized for each attempt using for example the roll of a dice and/or a coin flip. \added{The placement of the outer obstacles (i.e. $\frac{1}{4}$ X and $\frac{3}{4}$ X) shall be adjusted so that the distance between the obstacles and the white tape is smaller than the width of the robot.}
 
 \vspace{2em}
 {\bfseries Execution}
@@ -34,7 +33,7 @@ Nine locations are possible for obstacle placement at increments of $\frac{1}{4}
 \item The robot is placed on the side line of the field (marked as A in Figure~\ref{fig:obs-nav}) in the middle of the field strip.
 \item Teams may start the robot manually by pressing a button.
 \item A chronometer is started when the robot starts moving (including head movements).
-\item The run stops when the robot fully exits the field strip, reaches the opposite side. The team may abort the run.
+\item The run stops when the robot fully exits the field strip or reaches the opposite side. The team may abort the run.
 \item The chronometer is stopped when the robot touches the sideline on the opposite side of the field.
 
 \end{enumerate}
@@ -65,4 +64,4 @@ Teams are ranked on their best run according to the following criteria:
 \begin{enumerate}
 \item Duration of a \textit{Successful} run
 \item Duration of a \textit{Partially Successful} run
-\end{enumerate}}
+\end{enumerate}


### PR DESCRIPTION
SQ853
This discussion deals with enhancing the Partial success or Success conditions of
Technical Challenge Part F: Obstacle Navigation Challenge In the RC-HL-2024 Rules.
The following are additional suggestions to prevent scoring when the robot walks straight to the sideline while stepping on the lines on both sides:

Setup B (alternative): The width of the obstacles adjacent to the lines on both sides must be narrower than the width of the robot.

In the case of Setup B, the robot can avoid obstacles by stepping on the lines on both sides and complete the field, so it guarantees the freedom of the team's robot to complete the challenge more than Setup A.