### PR TITLE
Voting 2025-16-declined

### DIFF
--- a/Section_II/competition_and_trophies.tex
+++ b/Section_II/competition_and_trophies.tex
@@ -116,40 +116,44 @@ Physical competitions start with the Drop-In tournament.
 
   \bigskip
 
-  If at least 16 full teams participate in a league,
-  the teams are separated in two different divisions for the regular tournament:
+  If at least \removed{16}\added{12} full teams participate in a league,
+  the teams are separated \removed{in two different divisions for the regular tournament}\added{into 4 round robin groups A, B, C, D according to their ranking in Drop-in games}:
   \begin{itemize}
-  \item The best $N$ full teams are qualified for the first round robin of division A
-    \footnote{$N$ is either 8 or 12 depending on the number of full teams and
-      has to be announced before the beginning of the tournament.}.
-  \item The other full teams are qualified for the first round robin of division B.
+  \item \removed{The best $N$ full teams are qualified for the first round robin of division A}
+    \footnote{\removed{$N$ is either 8 or 12 depending on the number of full teams and
+      has to be announced before the beginning of the tournament.}}.
+  \item \removed{The other full teams are qualified for the first round robin of division B}.
+  \item \added{ group A composed from teams ranked 1, 8, 9, 16, 17, 24}
+  \item \added{ group B composed from teams ranked 2, 7, 10, 15, 18, 23}
+  \item \added{ group C composed from teams ranked 3, 6, 11, 14, 19, 22}
+  \item \added{ group D composed from teams ranked 4, 5, 12, 13, 20, 21}
   \end{itemize}
   
-  In the virtual competition, the qualification for division A and division B as well as the seeding for the round robin groups is determined prior to the first game of the main tournament. It may be based on an initial round of games, penalty shoot-outs, results from the previous RoboCup competition, or another similarly appropriate method determined by the Organizing Committee. The method of seeding needs to be announced at least one month prior to the start of the tournament.
+\bigskip
 
-  Both divisions play separate round robins. 
+\added{Round robin games are followed by round of 16 elimination games, Quarter Final games, Semifinal games, 3-rd Place game and Final game.}
+
+\added{In case if number of teams in tournament is less than 12, then 2 groups of round robin will be played.}
+
+\bigskip
+
+  In the virtual competition\removed{, the qualification for division A and division B as well as} the seeding for the round robin groups is determined prior to the first game of the main tournament. It may be based on an initial round of games, penalty shoot-outs, results from the previous RoboCup competition, or another similarly appropriate method determined by the Organizing Committee. The method of seeding needs to be announced at least one month prior to the start of the tournament.
+
+  \removed{Both divisions play separate round robins. 
   The lowest ranked teams per group in division A will have a playoff
   with the highest ranked teams per group in division B.
   The winners of the playoff games are qualified for the second round robin of
   division A, the losers will play the second round robin in
-  division B.
+  division B.}
   
-  Thereafter, division A and division B proceed independently of each other and 
-  each will normally consist of a round robin stage, followed by a number of knockout matches. 
+  \removed{Thereafter, division A and division B proceed independently of each other and 
+  each will normally consist of a round robin stage, followed by a number of knockout matches.} 
 
   
   \bigskip
 
-  In case there is less than 16 full teams, there is only one division with a
-  first round robin and a number of knock-out games.
-
-\bigskip
-
-All teams of a group play once against each other.
-The round robin games may end in a draw.
-In this case, both teams receive one point.
-Otherwise, the winning team receives three points and the not winning team
-receives zero points.
+  \removed{In case there is less than 16 full teams, there is only one division with a
+  first round robin and a number of knock-out games.}
 
 \bigskip
 


### PR DESCRIPTION
SQ634
Change the standard tournament format to round robin followed by a Round of 16

The tournament structure of a round robin followed by a round of 16 elimination worked well in 2024, allowing for a reasonable number of games for all teams. Currently this format is not in conformity with rules. 
The proposal is to make this format the standard for the competition.