### PR TITLE
Voting 2025-18

### DIFF
--- a/Section_III/moving-ball.tex
+++ b/Section_III/moving-ball.tex
@@ -1,14 +1,14 @@
 \clearpage
 \sffamily
 {\bfseries\color[rgb]{0.4,0.4,0.4}
-Part C: Goal-Kick from Moving Ball}
+Part C: \removed{Goal-}\added{Dynamic-}Kick from Moving Ball}
 \phantomsection
-\addcontentsline{toc}{subsection}{Part C: Goal-Kick from Moving Ball}
+\addcontentsline{toc}{subsection}{Part C: \removed{Goal-}\added{Dynamic-}Kick from Moving Ball}
 
 
 \bigskip
 
-The goal of the goal-kick from a moving ball challenge is to kick a moving ball
+The goal of the \removed{goal-}\added{dynamic-}kick from a moving ball challenge is to kick a moving ball
 into the goal. Results of the technical challenge are based on a batch of three runs.
 
 \bigskip


### PR DESCRIPTION
SQ668
There was used misspelling of “Goal-Kick” term in challenge with name “Goal Kick from Moving Ball”. 
“Goal Kick” – is a term describing restarting the game after the game was stopped due to ball crossing a goal line beyond goals with the last player which touched the ball was the player from attacking team.  Term “Goal Kick” is used in incorrect way misleading to wrong game situation. Correct way is to use word “Kick” without “Goal”.
It is proposed to change name of challenge to “Dynamic-Kick from Moving Ball”.