### PR TITLE
Changing humanoid robocup web link

### DIFF
--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -217,8 +217,7 @@ The source code of the game controller/referee box is available from
 \textcolor[rgb]{0.0,0.0,0.49803922}{https://github.com/RoboCup-Humanoid-TC/GameController},
 see also 
 
-\removed{\textcolor[rgb]{0.0,0.0,0.49803922}{https://www.robocuphumanoid.org}}
-\added{\textcolor[rgb]{0.0,0.0,0.49803922}{https://www.humanoid.robocup.org}}.
+\textcolor[rgb]{0.0,0.0,0.49803922}{https://humanoid.robocup.org}.
 
 \simplify{
 \bigskip

--- a/Section_I/law4.tex
+++ b/Section_I/law4.tex
@@ -217,7 +217,8 @@ The source code of the game controller/referee box is available from
 \textcolor[rgb]{0.0,0.0,0.49803922}{https://github.com/RoboCup-Humanoid-TC/GameController},
 see also 
 
-\textcolor[rgb]{0.0,0.0,0.49803922}{https://www.robocuphumanoid.org}.
+\removed{\textcolor[rgb]{0.0,0.0,0.49803922}{https://www.robocuphumanoid.org}}
+\added{\textcolor[rgb]{0.0,0.0,0.49803922}{https://www.humanoid.robocup.org}}.
 
 \simplify{
 \bigskip


### PR DESCRIPTION
Update of link from www.robocuphumanoid.org to www.humanoid.robocup.org